### PR TITLE
Misc updates after rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /target
 Cargo.lock
+
+# ide files
+rusty-tags.vi
+.idea
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Renamed to `ftdi-embedded-hal`.
+
 ## [0.9.1] - 2021-08-10
 ### Fixed
 - Call `close()` on Drop, allowing recovery from failures in `init()`.
@@ -93,15 +97,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2020-09-12
 - Initial release
 
-[Unreleased]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.9.1...HEAD
-[0.9.1]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.9.0...v0.9.1
-[0.9.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.5.1...v0.6.0
-[0.5.1]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.5.0...v0.5.1
-[0.5.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/newAM/ftd2xx-embedded-hal/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/newAM/ftd2xx-embedded-hal/releases/tag/v0.1.0
+[Unreleased]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/ftdi-rs/ftdi-embedded-hal/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ftd2xx-embedded-hal"
+name = "ftdi-embedded-hal"
 version = "0.9.1"
 authors = ["Alex M. <alexmgit@protonmail.com>"]
 description = "embedded-hal implementation for FTDI USB devices."
@@ -7,8 +7,8 @@ keywords = ["ftdi", "usb", "io", "hal"]
 categories = ["embedded"]
 edition = "2018"
 license = "MIT"
-repository = "https://github.com/newAM/ftd2xx-embedded-hal/"
-documentation = "https://docs.rs/ftd2xx-embedded-hal"
+repository = "https://github.com/ftdi-rs/ftdi-embedded-hal/"
+documentation = "https://docs.rs/ftdi-embedded-hal"
 readme = "README.md"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![Maintenance](https://img.shields.io/badge/maintenance-experimental-blue.svg)
-[![crates.io](https://img.shields.io/crates/v/ftd2xx-embedded-hal.svg)](https://crates.io/crates/ftd2xx-embedded-hal)
-[![docs.rs](https://docs.rs/ftd2xx-embedded-hal/badge.svg)](https://docs.rs/ftd2xx-embedded-hal/)
-[![Build Status](https://github.com/newAM/ftd2xx-embedded-hal/workflows/CI/badge.svg)](https://github.com/newAM/ftd2xx-embedded-hal/actions)
+[![crates.io](https://img.shields.io/crates/v/ftdi-embedded-hal.svg)](https://crates.io/crates/ftdi-embedded-hal)
+[![docs.rs](https://docs.rs/ftdi-embedded-hal/badge.svg)](https://docs.rs/ftdi-embedded-hal/)
+[![Build Status](https://github.com/ftdi-rs/ftdi-embedded-hal/workflows/CI/badge.svg)](https://github.com/ftdi-rs/ftdi-embedded-hal/actions)
 
-# ftd2xx-embedded-hal
+# ftdi-embedded-hal
 
 Inspired by [ftdi-embedded-hal] this is an [embedded-hal] implementation
 for the for the FTDI chips using the [libftd2xx] drivers.
@@ -25,7 +25,7 @@ FTDI device into the [embedded-hal] traits.
 * Linux users only: Add [udev rules].
 
 ```toml
-[dependencies.ftd2xx-embedded-hal]
+[dependencies.ftdi-embedded-hal]
 version = "~0.9.1"
 features = ["static"]
 ```
@@ -39,7 +39,7 @@ features = ["static"]
 
 ```rust
 use embedded_hal::prelude::*;
-use ftd2xx_embedded_hal::Ft232hHal;
+use ftdi_embedded_hal::Ft232hHal;
 
 let ftdi = Ft232hHal::new()?.init_default()?;
 let mut spi = ftdi.spi()?;
@@ -49,7 +49,7 @@ let mut spi = ftdi.spi()?;
 
 ```rust
 use embedded_hal::prelude::*;
-use ftd2xx_embedded_hal::Ft232hHal;
+use ftdi_embedded_hal::Ft232hHal;
 
 let ftdi = Ft232hHal::new()?.init_default()?;
 let mut i2c = ftdi.i2c()?;
@@ -59,7 +59,7 @@ let mut i2c = ftdi.i2c()?;
 
 ```rust
 use embedded_hal::prelude::*;
-use ftd2xx_embedded_hal::Ft232hHal;
+use ftdi_embedded_hal::Ft232hHal;
 
 let ftdi = Ft232hHal::new()?.init_default()?;
 let mut gpio = ftdi.ad6();
@@ -71,10 +71,10 @@ let mut gpio = ftdi.ad6();
 * Limited device support: FT232H, FT2232H, FT4232H.
 
 [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-[ftdi-embedded-hal]: https://github.com/geomatsi/ftdi-embedded-hal
-[libftd2xx crate]: https://github.com/newAM/libftd2xx-rs/
-[libftd2xx]: https://github.com/newAM/libftd2xx-rs
+[ftdi-embedded-hal-archive]: https://github.com/geomatsi/ftdi-embedded-hal-archive
+[libftd2xx crate]: https://github.com/ftdi-rs/libftd2xx-rs/
+[libftd2xx]: https://github.com/ftdi-rs/libftd2xx-rs
 [newAM/eeprom25aa02e48-rs]: https://github.com/newAM/eeprom25aa02e48-rs/blob/main/examples/ftdi.rs
 [newAM/bme280-rs]: https://github.com/newAM/bme280-rs/blob/main/examples/ftdi.rs
-[udev rules]: https://github.com/newAM/libftd2xx-rs/#udev-rules
+[udev rules]: https://github.com/ftdi-rs/libftd2xx-rs/#udev-rules
 [setup executable]: https://www.ftdichip.com/Drivers/CDM/CDM21228_Setup.zip

--- a/README.tpl
+++ b/README.tpl
@@ -1,7 +1,7 @@
 {{badges}}
-[![crates.io](https://img.shields.io/crates/v/ftd2xx-embedded-hal.svg)](https://crates.io/crates/ftd2xx-embedded-hal)
-[![docs.rs](https://docs.rs/ftd2xx-embedded-hal/badge.svg)](https://docs.rs/ftd2xx-embedded-hal/)
-[![Build Status](https://github.com/newAM/ftd2xx-embedded-hal/workflows/CI/badge.svg)](https://github.com/newAM/ftd2xx-embedded-hal/actions)
+[![crates.io](https://img.shields.io/crates/v/ftdi-embedded-hal.svg)](https://crates.io/crates/ftdi-embedded-hal)
+[![docs.rs](https://docs.rs/ftdi-embedded-hal/badge.svg)](https://docs.rs/ftdi-embedded-hal/)
+[![Build Status](https://github.com/ftdi-rs/ftdi-embedded-hal/workflows/CI/badge.svg)](https://github.com/ftdi-rs/ftdi-embedded-hal/actions)
 
 # {{crate}}
 

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -1,5 +1,5 @@
 use embedded_hal::digital::v2::OutputPin;
-use ftd2xx_embedded_hal as hal;
+use ftdi_embedded_hal as hal;
 use std::{thread::sleep, time::Duration};
 
 const NUM_BLINK: usize = 10;

--- a/examples/bme280.rs
+++ b/examples/bme280.rs
@@ -8,7 +8,7 @@
 //! * https://www.adafruit.com/product/4472
 
 use embedded_hal::prelude::*;
-use ftd2xx_embedded_hal as hal;
+use ftdi_embedded_hal as hal;
 
 fn main() {
     let ftdi = hal::Ft232hHal::new()

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -16,7 +16,7 @@ impl Delay {
     /// # Example
     ///
     /// ```
-    /// use ftd2xx_embedded_hal::Delay;
+    /// use ftdi_embedded_hal::Delay;
     ///
     /// let mut my_delay: Delay = Delay::new();
     /// ```

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -96,7 +96,7 @@ impl<'a, Device: FtdiCommon> I2c<'a, Device> {
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
     /// let mut i2c = ftdi.i2c()?;
@@ -120,7 +120,7 @@ impl<'a, Device: FtdiCommon> I2c<'a, Device> {
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
     /// let mut i2c = ftdi.i2c()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! * Linux users only: Add [udev rules].
 //!
 //! ```toml
-//! [dependencies.ftd2xx-embedded-hal]
+//! [dependencies.ftdi-embedded-hal]
 //! version = "~0.9.1"
 //! features = ["static"]
 //! ```
@@ -32,7 +32,7 @@
 //!
 //! ```no_run
 //! use embedded_hal::prelude::*;
-//! use ftd2xx_embedded_hal::Ft232hHal;
+//! use ftdi_embedded_hal::Ft232hHal;
 //!
 //! let ftdi = Ft232hHal::new()?.init_default()?;
 //! let mut spi = ftdi.spi()?;
@@ -43,7 +43,7 @@
 //!
 //! ```no_run
 //! use embedded_hal::prelude::*;
-//! use ftd2xx_embedded_hal::Ft232hHal;
+//! use ftdi_embedded_hal::Ft232hHal;
 //!
 //! let ftdi = Ft232hHal::new()?.init_default()?;
 //! let mut i2c = ftdi.i2c()?;
@@ -54,7 +54,7 @@
 //!
 //! ```no_run
 //! use embedded_hal::prelude::*;
-//! use ftd2xx_embedded_hal::Ft232hHal;
+//! use ftdi_embedded_hal::Ft232hHal;
 //!
 //! let ftdi = Ft232hHal::new()?.init_default()?;
 //! let mut gpio = ftdi.ad6();
@@ -67,14 +67,14 @@
 //! * Limited device support: FT232H, FT2232H, FT4232H.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//! [ftdi-embedded-hal]: https://github.com/geomatsi/ftdi-embedded-hal
-//! [libftd2xx crate]: https://github.com/newAM/libftd2xx-rs/
-//! [libftd2xx]: https://github.com/newAM/libftd2xx-rs
+//! [ftdi-embedded-hal-archive]: https://github.com/geomatsi/ftdi-embedded-hal-archive
+//! [libftd2xx crate]: https://github.com/ftdi-rs/libftd2xx-rs/
+//! [libftd2xx]: https://github.com/ftdi-rs/libftd2xx-rs
 //! [newAM/eeprom25aa02e48-rs]: https://github.com/newAM/eeprom25aa02e48-rs/blob/main/examples/ftdi.rs
 //! [newAM/bme280-rs]: https://github.com/newAM/bme280-rs/blob/main/examples/ftdi.rs
-//! [udev rules]: https://github.com/newAM/libftd2xx-rs/#udev-rules
+//! [udev rules]: https://github.com/ftdi-rs/libftd2xx-rs/#udev-rules
 //! [setup executable]: https://www.ftdichip.com/Drivers/CDM/CDM21228_Setup.zip
-#![doc(html_root_url = "https://docs.rs/ftd2xx-embedded-hal/0.9.1")]
+#![doc(html_root_url = "https://docs.rs/ftdi-embedded-hal/0.9.1")]
 #![forbid(missing_docs)]
 #![forbid(unsafe_code)]
 
@@ -201,7 +201,7 @@ impl<Device: FtdiCommon + TryFrom<Ftdi, Error = DeviceTypeError> + FtdiMpsse>
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
@@ -216,7 +216,7 @@ impl<Device: FtdiCommon + TryFrom<Ftdi, Error = DeviceTypeError> + FtdiMpsse>
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::with_serial_number("FT6ASGXH")?.init_default()?;
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
@@ -257,7 +257,7 @@ impl<Device: FtdiCommon + TryFrom<Ftdi, Error = DeviceTypeError> + FtdiMpsse>
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     /// use hal::{Ft232hHal, Initialized, Uninitialized};
     ///
     /// let ftdi: Ft232hHal<Uninitialized> = hal::Ft232hHal::new()?;
@@ -292,7 +292,7 @@ impl<Device: FtdiCommon + TryFrom<Ftdi, Error = DeviceTypeError> + FtdiMpsse>
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     /// use hal::libftd2xx::MpsseSettings;
     /// use hal::{Ft232hHal, Initialized, Uninitialized};
     ///
@@ -333,7 +333,7 @@ impl<Device: FtdiCommon> From<Device> for FtHal<Device, Uninitialized> {
     /// Selecting a device with a specific serial number.
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     /// use hal::libftd2xx::Ft232h;
     /// use hal::Ft232hHal;
     ///
@@ -345,7 +345,7 @@ impl<Device: FtdiCommon> From<Device> for FtHal<Device, Uninitialized> {
     /// Selecting a device with a specific description.
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     /// use hal::libftd2xx::Ft232h;
     /// use hal::FtHal;
     ///
@@ -376,7 +376,7 @@ impl<Device: FtdiCommon> FtHal<Device, Initialized> {
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
     /// let mut spi = ftdi.spi()?;
@@ -403,7 +403,7 @@ impl<Device: FtdiCommon> FtHal<Device, Initialized> {
     /// # Example
     ///
     /// ```no_run
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
     /// let mut i2c = ftdi.i2c()?;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -56,7 +56,7 @@ impl<'a, Device: FtdiCommon> Spi<'a, Device> {
     ///
     /// ```no_run
     /// use embedded_hal::spi::Polarity;
-    /// use ftd2xx_embedded_hal as hal;
+    /// use ftdi_embedded_hal as hal;
     ///
     /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
     /// let mut spi = ftdi.spi()?;


### PR DESCRIPTION
The crate has been renamed to ftdi-embedded-hal. Update all the links
and examples to use the new name and location.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>