### PR TITLE
generic backend support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,47 @@ jobs:
           toolchain: stable
       - run: RUSTFLAGS="-D warnings" cargo build
 
-  test:
-    name: Cargo Test
+  examples:
+    name: Cargo Examples
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - libftd2xx
+          - ftdi
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: RUSTFLAGS="-D warnings" cargo test
+      - run: |
+          if ${{ matrix.features == 'ftdi' }}
+          then
+            sudo apt-get update
+            sudo apt-get install -y libftdi1 libftdi1-dev pkg-config
+          fi
+          RUSTFLAGS="-D warnings" cargo build --features ${{ matrix.features }} --examples
+
+  test:
+    name: Cargo Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - libftd2xx
+          - ftdi
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: |
+          if ${{ matrix.features == 'ftdi' }}
+          then
+            sudo apt-get update
+            sudo apt-get install -y libftdi1 libftdi1-dev pkg-config
+          fi
+          RUSTFLAGS="-D warnings" cargo test --features ${{ matrix.features }}
 
   doc:
     name: Cargo Doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ftdi = { version = "0.1.3", optional = true }
 [dev-dependencies]
 version-sync = "~0.9.2"
 eeprom24x = "0.3.0"
+lm75 = "0.2.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,15 @@ documentation = "https://docs.rs/ftdi-embedded-hal"
 readme = "README.md"
 
 [features]
-static = ["libftd2xx/static"]
+libftd2xx-static = ["libftd2xx/static"]
+default = []
 
 [dependencies]
 nb = "^1"
 embedded-hal = "~0.2.4"
-libftd2xx = "~0.31.0"
+ftdi-mpsse = "^0.1"
+libftd2xx = { version = "0.32.0", optional = true }
+ftdi = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 version-sync = "~0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ftdi = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 version-sync = "~0.9.2"
+spi-memory = "0.2.0"
 eeprom24x = "0.3.0"
 lm75 = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ftdi = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 version-sync = "~0.9.2"
+eeprom24x = "0.3.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/examples/at24c04.rs
+++ b/examples/at24c04.rs
@@ -1,0 +1,63 @@
+use eeprom24x::Eeprom24x;
+use eeprom24x::SlaveAddr;
+use ftdi_embedded_hal as hal;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[cfg(all(feature = "ftdi", feature = "libftd2xx"))]
+compile_error!("features 'ftdi' and 'libftd2xx' cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "ftdi", feature = "libftd2xx")))]
+compile_error!("one of features 'ftdi' and 'libftd2xx' shall be enabled");
+
+fn main() {
+    #[cfg(feature = "ftdi")]
+    let device = ftdi::find_by_vid_pid(0x0403, 0x6014)
+        .interface(ftdi::Interface::A)
+        .open()
+        .unwrap();
+
+    #[cfg(feature = "libftd2xx")]
+    let device = libftd2xx::Ft232h::with_description("Single RS232-HS").unwrap();
+
+    let hal = hal::FtHal::init_freq(device, 400_000).unwrap();
+    let i2c = hal.i2c().unwrap();
+    let mut eeprom = Eeprom24x::new_24x04(i2c, SlaveAddr::default());
+    let delay = Duration::from_millis(5);
+
+    // check high memory addresses: 1 bit passed as a part of i2c addr
+    let addrs1: [u32; 4] = [0x100, 0x10F, 0x1F0, 0x1EE];
+    let byte_w1 = 0xe5;
+    let addrs2: [u32; 4] = [0x00, 0x0F, 0xF0, 0xEE];
+    let byte_w2 = 0xaa;
+
+    // write bytes
+
+    for addr in addrs1.iter() {
+        println!("Write byte {:#x} to address {:#x}", byte_w1, *addr);
+        eeprom.write_byte(*addr, byte_w1).unwrap();
+        sleep(delay);
+    }
+
+    for addr in addrs2.iter() {
+        println!("Write byte {:#x} to address {:#x}", byte_w2, *addr);
+        eeprom.write_byte(*addr, byte_w2).unwrap();
+        sleep(delay);
+    }
+
+    // read bytes and check
+
+    for addr in addrs1.iter() {
+        let byte_r = eeprom.read_byte(*addr).unwrap();
+        println!("Read byte from address {:#x}: {:#x}", *addr, byte_r);
+        assert_eq!(byte_w1, byte_r);
+        sleep(delay);
+    }
+
+    for addr in addrs2.iter() {
+        let byte_r = eeprom.read_byte(*addr).unwrap();
+        println!("Read byte from address {:#x}: {:#x}", *addr, byte_r);
+        assert_eq!(byte_w2, byte_r);
+        sleep(delay);
+    }
+}

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -2,15 +2,30 @@ use embedded_hal::digital::v2::OutputPin;
 use ftdi_embedded_hal as hal;
 use std::{thread::sleep, time::Duration};
 
+#[cfg(feature = "libftd2xx")]
+use std::convert::TryInto;
+
 const NUM_BLINK: usize = 10;
 const SLEEP_DURATION: Duration = Duration::from_millis(500);
 
+#[cfg(all(feature = "ftdi", feature = "libftd2xx"))]
+compile_error!("features 'ftdi' and 'libftd2xx' cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "ftdi", feature = "libftd2xx")))]
+compile_error!("one of features 'ftdi' and 'libftd2xx' shall be enabled");
+
 fn main() {
-    let ftdi = hal::Ft232hHal::new()
-        .expect("Failed to open FT232H device")
-        .init_default()
-        .expect("Failed to initialize MPSSE");
-    let mut output_pin = ftdi.ad3();
+    #[cfg(feature = "libftd2xx")]
+    let device: libftd2xx::Ft232h = libftd2xx::Ftdi::new().unwrap().try_into().unwrap();
+
+    #[cfg(feature = "ftdi")]
+    let device = ftdi::find_by_vid_pid(0x0403, 0x6014)
+        .interface(ftdi::Interface::A)
+        .open()
+        .unwrap();
+
+    let hal = hal::FtHal::init_default(device).unwrap();
+    let mut output_pin = hal.ad3();
 
     println!("Starting blinky example");
     for n in 0..NUM_BLINK {

--- a/examples/bme280.rs
+++ b/examples/bme280.rs
@@ -10,12 +10,27 @@
 use embedded_hal::prelude::*;
 use ftdi_embedded_hal as hal;
 
+#[cfg(feature = "libftd2xx")]
+use std::convert::TryInto;
+
+#[cfg(all(feature = "ftdi", feature = "libftd2xx"))]
+compile_error!("features 'ftdi' and 'libftd2xx' cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "ftdi", feature = "libftd2xx")))]
+compile_error!("one of features 'ftdi' and 'libftd2xx' shall be enabled");
+
 fn main() {
-    let ftdi = hal::Ft232hHal::new()
-        .expect("Failed to open FT232H device")
-        .init_default()
-        .expect("Failed to initialize MPSSE");
-    let mut i2c = ftdi.i2c().expect("Failed to initialize I2C");
+    #[cfg(feature = "libftd2xx")]
+    let device: libftd2xx::Ft232h = libftd2xx::Ftdi::new().unwrap().try_into().unwrap();
+
+    #[cfg(feature = "ftdi")]
+    let device = ftdi::find_by_vid_pid(0x0403, 0x6014)
+        .interface(ftdi::Interface::A)
+        .open()
+        .unwrap();
+
+    let hal = hal::FtHal::init_default(device).unwrap();
+    let mut i2c = hal.i2c().unwrap();
 
     let mut buf: [u8; 1] = [0];
     const BME280_ADDR: u8 = 0b1110111;

--- a/examples/lm75.rs
+++ b/examples/lm75.rs
@@ -1,0 +1,32 @@
+use ftdi_embedded_hal as hal;
+use lm75::{Address, Lm75};
+use std::thread::sleep;
+use std::time::Duration;
+
+#[cfg(all(feature = "ftdi", feature = "libftd2xx"))]
+compile_error!("features 'ftdi' and 'libftd2xx' cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "ftdi", feature = "libftd2xx")))]
+compile_error!("one of features 'ftdi' and 'libftd2xx' shall be enabled");
+
+fn main() {
+    #[cfg(feature = "ftdi")]
+    let device = ftdi::find_by_vid_pid(0x0403, 0x6014)
+        .interface(ftdi::Interface::A)
+        .open()
+        .unwrap();
+
+    #[cfg(feature = "libftd2xx")]
+    let device = libftd2xx::Ft232h::with_description("Single RS232-HS").unwrap();
+
+    let hal = hal::FtHal::init_freq(device, 400_000).unwrap();
+    let i2c = hal.i2c().unwrap();
+    let mut sensor = Lm75::new(i2c, Address::default());
+    let delay = Duration::from_secs(1);
+
+    loop {
+        let temperature = sensor.read_temperature().unwrap();
+        println!("Temperature: {}", temperature);
+        sleep(delay);
+    }
+}

--- a/examples/spi-flash.rs
+++ b/examples/spi-flash.rs
@@ -1,0 +1,69 @@
+use ftdi_embedded_hal as hal;
+use spi_memory::prelude::*;
+use spi_memory::series25::Flash;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[cfg(all(feature = "ftdi", feature = "libftd2xx"))]
+compile_error!("features 'ftdi' and 'libftd2xx' cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "ftdi", feature = "libftd2xx")))]
+compile_error!("one of features 'ftdi' and 'libftd2xx' shall be enabled");
+
+const LINE: u32 = 0x10;
+
+fn main() {
+    #[cfg(feature = "ftdi")]
+    let device = ftdi::find_by_vid_pid(0x0403, 0x6014)
+        .interface(ftdi::Interface::A)
+        .open()
+        .unwrap();
+
+    #[cfg(feature = "libftd2xx")]
+    let device = libftd2xx::Ft232h::with_description("Single RS232-HS").unwrap();
+
+    let hal = hal::FtHal::init_freq(device, 1_000_000).unwrap();
+    let spi = hal.spi().unwrap();
+    let ncs = hal.ad3();
+    let delay = Duration::from_millis(10);
+
+    let mut flash = Flash::init(spi, ncs).unwrap();
+    let id = flash.read_jedec_id().unwrap();
+    println!("JEDEC ID: {:?}", id);
+
+    #[cfg(feature = "libftd2xx")]
+    let data: [u8; 8] = [0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70];
+    #[cfg(feature = "ftdi")]
+    let data: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
+    let addrs: [u32; 5] = [0, LINE, 2 * LINE, 3 * LINE, 4 * LINE];
+    let zero: [u8; 8] = [0; 8];
+    let mut bytes_w: [u8; 8] = [0; 8];
+    let mut bytes_r: [u8; 8] = [0; 8];
+
+    println!("Write to flash...");
+    for addr in addrs.iter() {
+        bytes_w.copy_from_slice(&data);
+        println!("Write bytes {:02x?} to address {:02x}", bytes_w, *addr);
+        flash.write_bytes(*addr, &mut bytes_w).unwrap();
+        sleep(delay);
+    }
+
+    println!("Read from flash and check...");
+    for addr in addrs.iter() {
+        bytes_r.copy_from_slice(&zero);
+        flash.read(*addr, &mut bytes_r).unwrap();
+        println!("Read byte from address {:02x}: {:02x?}", *addr, bytes_r);
+        assert_eq!(data, bytes_r);
+        sleep(delay);
+    }
+
+    let mut buf = [0; LINE as usize];
+    let mut addr = 0;
+    println!("Dump flash...");
+    while addr < 0x100 {
+        flash.read(addr, &mut buf).unwrap();
+        println!("{:02x}: {:02x?}", addr, buf);
+        addr += LINE as u32;
+    }
+}

--- a/examples/ws2812.rs
+++ b/examples/ws2812.rs
@@ -1,0 +1,57 @@
+use embedded_hal::blocking::spi::Write;
+use ftdi_embedded_hal as hal;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[cfg(all(feature = "ftdi", feature = "libftd2xx"))]
+compile_error!("features 'ftdi' and 'libftd2xx' cannot be enabled at the same time");
+
+#[cfg(not(any(feature = "ftdi", feature = "libftd2xx")))]
+compile_error!("one of features 'ftdi' and 'libftdi2xx' shall be enabled");
+
+fn main() {
+    #[cfg(feature = "libftd2xx")]
+    let device = libftd2xx::Ft2232h::with_description("Dual RS232-HS A").unwrap();
+
+    #[cfg(feature = "ftdi")]
+    let device = ftdi::find_by_vid_pid(0x0403, 0x6010)
+        .interface(ftdi::Interface::A)
+        .open()
+        .unwrap();
+
+    let hal = hal::FtHal::init_freq(device, 3_000_000).unwrap();
+    let mut spi = hal.spi().unwrap();
+
+    // spi sequence for ws2812 color value 0x10
+    let b1 = [0x92, 0x69, 0x24];
+
+    // spi sequence for ws2812 color value 0x00
+    let b0 = [0x92, 0x49, 0x24];
+
+    // spi sequences for single led of specific color
+    let g = [b1, b0, b0];
+    let r = [b0, b1, b0];
+    let b = [b0, b0, b1];
+    let x = [b0, b0, b0];
+
+    // initial pattern
+    let mut pattern = vec![r, r, g, g, x, x, b, b];
+
+    println!("ready to go...");
+
+    loop {
+        println!("next pattern...");
+        let stream = pattern
+            .clone()
+            .into_iter()
+            .flatten()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<u8>>();
+
+        spi.write(stream.as_slice()).unwrap();
+        sleep(Duration::from_millis(400));
+        // rotate pattern
+        pattern.rotate_right(1);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,78 @@
+use std::fmt;
+use std::io;
+
+/// HAL error type combines 3 types of errors:
+/// * internal HAL errors
+/// * I/O errors
+/// * FTDI drivers errors
+#[derive(Debug)]
+pub enum Error<E: std::error::Error> {
+    Hal(ErrorKind),
+    Io(io::Error),
+    Backend(E),
+}
+/// Internal HAL errors
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    InvalidParams,
+    InvalidClock,
+    BusBusy,
+    I2cNoAck,
+    GpioPinBusy,
+    GpioInvalidPin,
+    SpiModeNotSupported,
+}
+
+impl ErrorKind {
+    fn as_str(&self) -> &str {
+        match *self {
+            ErrorKind::InvalidParams => "Invalid input params",
+            ErrorKind::BusBusy => "Bus is busy",
+            ErrorKind::InvalidClock => "Clock is not valid",
+            ErrorKind::I2cNoAck => "No ACK from slave",
+            ErrorKind::GpioPinBusy => "GPIO pin is already in use",
+            ErrorKind::GpioInvalidPin => "No such GPIO pin",
+            ErrorKind::SpiModeNotSupported => "Mode not supported",
+        }
+    }
+}
+
+impl<E: std::error::Error> fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(e) => e.fmt(f),
+            Error::Backend(e) => fmt::Display::fmt(&e, f),
+            Error::Hal(e) => write!(f, "A regular error occurred {:?}", e.as_str()),
+        }
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for Error<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => e.source(),
+            Error::Backend(e) => e.source(),
+            Error::Hal(_) => None,
+        }
+    }
+}
+
+impl<E: std::error::Error> From<io::Error> for Error<E> {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+#[cfg(feature = "ftdi")]
+impl From<ftdi::Error> for Error<ftdi::Error> {
+    fn from(e: ftdi::Error) -> Self {
+        Error::Backend(e)
+    }
+}
+
+#[cfg(feature = "libftd2xx")]
+impl From<libftd2xx::TimeoutError> for Error<libftd2xx::TimeoutError> {
+    fn from(e: libftd2xx::TimeoutError) -> Self {
+        Error::Backend(e)
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,5 +1,5 @@
 use crate::{FtInner, PinUse};
-use libftd2xx::{FtdiCommon, MpsseCmdBuilder, TimeoutError};
+use ftdi_mpsse::{MpsseCmdBuilder, MpsseCmdExecutor};
 use std::{cell::RefCell, sync::Mutex};
 
 /// FTDI output pin.
@@ -9,14 +9,16 @@ use std::{cell::RefCell, sync::Mutex};
 /// [`FtHal::ad0`]: crate::FtHal::ad0
 /// [`FtHal::ad7`]: crate::FtHal::ad7
 #[derive(Debug)]
-pub struct OutputPin<'a, Device: FtdiCommon> {
+pub struct OutputPin<'a, Device: MpsseCmdExecutor>
+{
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
     /// GPIO pin index.  0-7 for the FT232H.
     idx: u8,
 }
 
-impl<'a, Device: FtdiCommon> OutputPin<'a, Device> {
+impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device>
+{
     pub(crate) fn new(mtx: &'a Mutex<RefCell<FtInner<Device>>>, idx: u8) -> OutputPin<'a, Device> {
         let lock = mtx.lock().expect("Failed to aquire FTDI mutex");
         let mut inner = lock.borrow_mut();
@@ -37,18 +39,20 @@ impl<'a, Device: FtdiCommon> OutputPin<'a, Device> {
         let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()
             .set_gpio_lower(inner.value, inner.direction)
             .send_immediate();
-        inner.ft.write_all(cmd.as_slice())
+        inner.ft.send(cmd.as_slice())
     }
 }
 
-impl<'a, Device: FtdiCommon> OutputPin<'a, Device> {
+impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device>
+{
     /// Convert the GPIO pin index to a pin mask
     pub(crate) fn mask(&self) -> u8 {
         1 << self.idx
     }
 }
 
-impl<'a, Device: FtdiCommon> embedded_hal::digital::v2::OutputPin for OutputPin<'a, Device> {
+impl<'a, Device: MpsseCmdExecutor> embedded_hal::digital::v2::OutputPin for OutputPin<'a, Device>
+{
     type Error = TimeoutError;
 
     fn set_low(&mut self) -> Result<(), Self::Error> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,5 +1,7 @@
+use crate::error::Error;
 use crate::{FtInner, PinUse};
 use ftdi_mpsse::{MpsseCmdBuilder, MpsseCmdExecutor};
+use std::result::Result;
 use std::{cell::RefCell, sync::Mutex};
 
 /// FTDI output pin.
@@ -9,15 +11,18 @@ use std::{cell::RefCell, sync::Mutex};
 /// [`FtHal::ad0`]: crate::FtHal::ad0
 /// [`FtHal::ad7`]: crate::FtHal::ad7
 #[derive(Debug)]
-pub struct OutputPin<'a, Device: MpsseCmdExecutor>
-{
+pub struct OutputPin<'a, Device: MpsseCmdExecutor> {
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
     /// GPIO pin index.  0-7 for the FT232H.
     idx: u8,
 }
 
-impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device>
+impl<'a, Device, E> OutputPin<'a, Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
     pub(crate) fn new(mtx: &'a Mutex<RefCell<FtInner<Device>>>, idx: u8) -> OutputPin<'a, Device> {
         let lock = mtx.lock().expect("Failed to aquire FTDI mutex");
@@ -26,7 +31,7 @@ impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device>
         OutputPin { mtx, idx }
     }
 
-    pub(crate) fn set(&self, state: bool) -> Result<(), TimeoutError> {
+    pub(crate) fn set(&self, state: bool) -> Result<(), Error<E>> {
         let lock = self.mtx.lock().expect("Failed to aquire FTDI mutex");
         let mut inner = lock.borrow_mut();
 
@@ -39,27 +44,32 @@ impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device>
         let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()
             .set_gpio_lower(inner.value, inner.direction)
             .send_immediate();
-        inner.ft.send(cmd.as_slice())
+        inner.ft.send(cmd.as_slice())?;
+
+        Ok(())
     }
 }
 
-impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device>
-{
+impl<'a, Device: MpsseCmdExecutor> OutputPin<'a, Device> {
     /// Convert the GPIO pin index to a pin mask
     pub(crate) fn mask(&self) -> u8 {
         1 << self.idx
     }
 }
 
-impl<'a, Device: MpsseCmdExecutor> embedded_hal::digital::v2::OutputPin for OutputPin<'a, Device>
+impl<'a, Device, E> embedded_hal::digital::v2::OutputPin for OutputPin<'a, Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
-    type Error = TimeoutError;
+    type Error = Error<E>;
 
-    fn set_low(&mut self) -> Result<(), Self::Error> {
+    fn set_low(&mut self) -> Result<(), Error<E>> {
         self.set(false)
     }
 
-    fn set_high(&mut self) -> Result<(), Self::Error> {
+    fn set_high(&mut self) -> Result<(), Error<E>> {
         self.set(true)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -80,9 +80,13 @@ where
     /// ```no_run
     /// use ftdi_embedded_hal as hal;
     ///
-    /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
-    /// let mut i2c = ftdi.i2c()?;
+    /// # #[cfg(feature = "libftd2xx")]
+    /// # {
+    /// let device = libftd2xx::Ft2232h::with_description("Dual RS232-HS A")?;
+    /// let hal = hal::FtHal::init_freq(device, 3_000_000)?;
+    /// let mut i2c = hal.i2c()?;
     /// i2c.set_stop_start_len(10);
+    /// # }
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     pub fn set_stop_start_len(&mut self, start_stop_cmds: u8) {
@@ -104,9 +108,16 @@ where
     /// ```no_run
     /// use ftdi_embedded_hal as hal;
     ///
-    /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
-    /// let mut i2c = ftdi.i2c()?;
+    /// # #[cfg(feature = "ftdi")]
+    /// # {
+    /// let device = ftdi::find_by_vid_pid(0x0403, 0x6014)
+    ///     .interface(ftdi::Interface::A)
+    ///     .open()?;
+    ///
+    /// let hal = hal::FtHal::init_freq(device, 3_000_000)?;
+    /// let mut i2c = hal.i2c()?;
     /// i2c.set_fast(true);
+    /// # }
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     pub fn set_fast(&mut self, fast: bool) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,16 +82,18 @@ pub use embedded_hal;
 pub use ftdi_mpsse;
 
 mod delay;
+mod error;
 mod gpio;
 mod i2c;
 mod spi;
 
+use crate::error::Error;
 pub use delay::Delay;
 pub use gpio::OutputPin;
-pub use i2c::{I2c, I2cError};
+pub use i2c::I2c;
 pub use spi::Spi;
 
-use ftdi_mpsse::{MpsseSettings, MpsseCmdExecutor};
+use ftdi_mpsse::{MpsseCmdExecutor, MpsseSettings};
 use std::{cell::RefCell, sync::Mutex};
 
 /// State tracker for each pin on the FTDI chip.
@@ -157,7 +159,11 @@ pub struct FtHal<Device: MpsseCmdExecutor> {
     mtx: Mutex<RefCell<FtInner<Device>>>,
 }
 
-impl<Device: MpsseCmdExecutor> FtHal<Device>
+impl<Device, E> FtHal<Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
     /// Initialize the FTDI MPSSE with sane defaults.
     ///
@@ -180,16 +186,17 @@ impl<Device: MpsseCmdExecutor> FtHal<Device>
     /// let ftdi: Ft232hHal<Initialized> = ftdi.init_default()?;
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
-    pub fn init_default(device: Device) -> Result<FtHal<Device>> {
-        FtHal::init(device, &MpsseSettings::default())
+    pub fn init_default(device: Device) -> Result<FtHal<Device>, Error<E>> {
+        Ok(FtHal::init(device, &MpsseSettings::default())?)
     }
-    pub fn init_basic(device: Device, freq: u32) -> Result<FtHal<Device>> {
+
+    pub fn init_basic(device: Device, freq: u32) -> Result<FtHal<Device>, Error<E>> {
         let settings: MpsseSettings = MpsseSettings {
             clock_frequency: Some(freq),
             ..Default::default()
         };
 
-        FtHal::init(device, &settings)
+        Ok(FtHal::init(device, &settings)?)
     }
 
     /// Initialize the FTDI MPSSE with custom values.
@@ -220,21 +227,21 @@ impl<Device: MpsseCmdExecutor> FtHal<Device>
     /// ```
     ///
     /// [`MpsseSettings`]: libftd2xx::MpsseSettings
-    pub fn init(
-        mut device: Device,
-        mpsse_settings: &MpsseSettings,
-    ) -> Result<FtHal<Device>> {
+    pub fn init(mut device: Device, mpsse_settings: &MpsseSettings) -> Result<FtHal<Device>, E> {
         device.init(mpsse_settings)?;
 
         Ok(FtHal {
-            mtx: Mutex::new(RefCell::new(device.into()))
+            mtx: Mutex::new(RefCell::new(device.into())),
         })
     }
 }
 
-impl<Device: MpsseCmdExecutor> FtHal<Device>
+impl<Device, E> FtHal<Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
-
     /// Aquire the SPI peripheral for the FT232H.
     ///
     /// Pin assignments:
@@ -255,7 +262,7 @@ impl<Device: MpsseCmdExecutor> FtHal<Device>
     /// let mut spi = ftdi.spi()?;
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
-    pub fn spi(&self) -> Result<Spi<Device>, TimeoutError> {
+    pub fn spi(&self) -> Result<Spi<Device>, Error<E>> {
         Spi::new(&self.mtx)
     }
 
@@ -282,7 +289,7 @@ impl<Device: MpsseCmdExecutor> FtHal<Device>
     /// let mut i2c = ftdi.i2c()?;
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
-    pub fn i2c(&self) -> Result<I2c<Device>, TimeoutError> {
+    pub fn i2c(&self) -> Result<I2c<Device>, Error<E>> {
         I2c::new(&self.mtx)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,13 @@
 //! features = ["libftd2xx-static"]
 //! ```
 //!
-//! # Examples
+//! # Limitations
 //!
-//! * [newAM/eeprom25aa02e48-rs]
-//! * [newAM/bme280-rs]
+//! * Limited trait support: SPI, I2C, Delay, and OutputPin traits are implemented.
+//! * Limited device support: FT232H, FT2232H, FT4232H.
+//! * Limited SPI modes support: MODE0, MODE2.
+//!
+//! # Examples
 //!
 //! ## SPI
 //!
@@ -123,18 +126,17 @@
 //! # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
 //! ```
 //!
-//! # Limitations
+//! ## More examples
 //!
-//! * Limited trait support: SPI, I2C, Delay, and OutputPin traits are implemented.
-//! * Limited device support: FT232H, FT2232H, FT4232H.
-//! * Limited SPI modes support: MODE0, MODE2.
+//! * [newAM/eeprom25aa02e48-rs]: read data from Microchip 25AA02E48 SPI EEPROM
+//! * [newAM/bme280-rs]: read samples from Bosch BME280 sensor via I2C protocol
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
 //! [ftdi-rs]: https://github.com/tanriol/ftdi-rs
 //! [libftd2xx crate]: https://github.com/ftdi-rs/libftd2xx-rs/
 //! [libftd2xx]: https://github.com/ftdi-rs/libftd2xx-rs
 //! [newAM/eeprom25aa02e48-rs]: https://github.com/newAM/eeprom25aa02e48-rs/blob/main/examples/ftdi.rs
-//! [newAM/bme280-rs]: https://github.com/newAM/bme280-rs/blob/main/examples/ftdi.rs
+//! [newAM/bme280-rs]: https://github.com/newAM/bme280-rs/blob/main/examples/ftdi-i2c.rs
 //! [udev rules]: https://github.com/ftdi-rs/libftd2xx-rs/#udev-rules
 //! [setup executable]: https://www.ftdichip.com/Drivers/CDM/CDM21228_Setup.zip
 #![doc(html_root_url = "https://docs.rs/ftdi-embedded-hal/0.9.1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,10 +187,15 @@ where
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     pub fn init_default(device: Device) -> Result<FtHal<Device>, Error<E>> {
-        Ok(FtHal::init(device, &MpsseSettings::default())?)
+        let settings: MpsseSettings = MpsseSettings {
+            clock_frequency: Some(100_000),
+            ..Default::default()
+        };
+
+        Ok(FtHal::init(device, &settings)?)
     }
 
-    pub fn init_basic(device: Device, freq: u32) -> Result<FtHal<Device>, Error<E>> {
+    pub fn init_freq(device: Device, freq: u32) -> Result<FtHal<Device>, Error<E>> {
         let settings: MpsseSettings = MpsseSettings {
             clock_frequency: Some(freq),
             ..Default::default()

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,7 +1,9 @@
+use crate::error::Error;
 use crate::{FtInner, PinUse};
 use embedded_hal::spi::Polarity;
-use std::{cell::RefCell, sync::Mutex};
 use ftdi_mpsse::{ClockData, ClockDataOut, MpsseCmdBuilder, MpsseCmdExecutor};
+use std::result::Result;
+use std::{cell::RefCell, sync::Mutex};
 
 /// FTDI SPI interface.
 ///
@@ -9,8 +11,7 @@ use ftdi_mpsse::{ClockData, ClockDataOut, MpsseCmdBuilder, MpsseCmdExecutor};
 ///
 /// [`FtHal::spi`]: crate::FtHal::spi
 #[derive(Debug)]
-pub struct Spi<'a, Device: MpsseCmdExecutor>
-{
+pub struct Spi<'a, Device: MpsseCmdExecutor> {
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
     /// MPSSE command used to clock data in and out simultaneously.
@@ -23,9 +24,13 @@ pub struct Spi<'a, Device: MpsseCmdExecutor>
     clk_out: ClockDataOut,
 }
 
-impl<'a, Device: MpsseCmdExecutor> Spi<'a, Device>
+impl<'a, Device, E> Spi<'a, Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
-    pub(crate) fn new(mtx: &Mutex<RefCell<FtInner<Device>>>) -> Result<Spi<Device>, TimeoutError> {
+    pub(crate) fn new(mtx: &Mutex<RefCell<FtInner<Device>>>) -> Result<Spi<Device>, Error<E>> {
         let lock = mtx.lock().expect("Failed to aquire FTDI mutex");
         let mut inner = lock.borrow_mut();
         inner.allocate_pin(0, PinUse::Spi);
@@ -79,26 +84,37 @@ impl<'a, Device: MpsseCmdExecutor> Spi<'a, Device>
     }
 }
 
-impl<'a, Device: MpsseCmdExecutor> embedded_hal::blocking::spi::Write<u8> for Spi<'a, Device>
+impl<'a, Device, E> embedded_hal::blocking::spi::Write<u8> for Spi<'a, Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
-    type Error = TimeoutError;
+    type Error = Error<E>;
 
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+    fn write(&mut self, words: &[u8]) -> Result<(), Error<E>> {
         let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()
             .clock_data_out(self.clk_out, words)
             .send_immediate();
 
         let lock = self.mtx.lock().expect("Failed to aquire FTDI mutex");
         let mut inner = lock.borrow_mut();
-        inner.ft.send(cmd.as_slice())
+
+        inner.ft.send(cmd.as_slice())?;
+
+        Ok(())
     }
 }
 
-impl<'a, Device: MpsseCmdExecutor> embedded_hal::blocking::spi::Transfer<u8> for Spi<'a, Device>
+impl<'a, Device, E> embedded_hal::blocking::spi::Transfer<u8> for Spi<'a, Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
-    type Error = TimeoutError;
+    type Error = Error<E>;
 
-    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Error<E>> {
         let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()
             .clock_data(self.clk, words)
             .send_immediate();
@@ -112,11 +128,15 @@ impl<'a, Device: MpsseCmdExecutor> embedded_hal::blocking::spi::Transfer<u8> for
     }
 }
 
-impl<'a, Device: MpsseCmdExecutor> embedded_hal::spi::FullDuplex<u8> for Spi<'a, Device>
+impl<'a, Device, E> embedded_hal::spi::FullDuplex<u8> for Spi<'a, Device>
+where
+    Device: MpsseCmdExecutor<Error = E>,
+    E: std::error::Error,
+    Error<E>: From<E>,
 {
-    type Error = TimeoutError;
+    type Error = Error<E>;
 
-    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+    fn read(&mut self) -> nb::Result<u8, Error<E>> {
         let mut buf: [u8; 1] = [0];
         let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()
             .clock_data(self.clk, &buf)
@@ -124,20 +144,24 @@ impl<'a, Device: MpsseCmdExecutor> embedded_hal::spi::FullDuplex<u8> for Spi<'a,
 
         let lock = self.mtx.lock().expect("Failed to aquire FTDI mutex");
         let mut inner = lock.borrow_mut();
-        inner.ft.write_all(cmd.as_slice())?;
-        inner.ft.read_all(&mut buf)?;
 
-        Ok(buf[0])
+        match inner.ft.xfer(cmd.as_slice(), &mut buf) {
+            Ok(()) => Ok(buf[0]),
+            Err(e) => Err(nb::Error::Other(Error::from(e))),
+        }
     }
 
-    fn send(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
+    fn send(&mut self, byte: u8) -> nb::Result<(), Error<E>> {
         let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()
             .clock_data_out(self.clk_out, &[byte])
             .send_immediate();
 
         let lock = self.mtx.lock().expect("Failed to aquire FTDI mutex");
         let mut inner = lock.borrow_mut();
-        inner.ft.write_all(cmd.as_slice())?;
-        Ok(())
+
+        match inner.ft.send(cmd.as_slice()) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(nb::Error::Other(Error::from(e))),
+        }
     }
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -65,9 +65,13 @@ where
     /// use embedded_hal::spi::Polarity;
     /// use ftdi_embedded_hal as hal;
     ///
-    /// let ftdi = hal::Ft232hHal::new()?.init_default()?;
-    /// let mut spi = ftdi.spi()?;
+    /// # #[cfg(feature = "libftd2xx")]
+    /// # {
+    /// let device = libftd2xx::Ft2232h::with_description("Dual RS232-HS A")?;
+    /// let hal = hal::FtHal::init_freq(device, 3_000_000)?;
+    /// let mut spi = hal.spi()?;
     /// spi.set_clock_polarity(Polarity::IdleLow);
+    /// # }
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     ///


### PR DESCRIPTION
Hi @newAM 

Work had me busy this week, so this PR is still a WIP that needs a lot of cleanup. On the other hand, overall approach is already shaping up. So it is a good time to get feedback before proceeding with cleanup. By the way, new examples work fine with both `libftd2xx` and `ftdi-rs` backends.

Here are some highlights:
- `libftd2xx-rs` in use: current master https://github.com/ftdi-rs/libftd2xx, we haven't yet pushed new release with ftdi-mpsse support
- `ftdi-rs` in use: [common-ftdimpsse](https://github.com/geomatsi/ftdi-rs/tree/common-ftdimpsse) development branch, not yet submitted for review
- updated error handling approach: new HAL error type that includes its own errors as well as errors of supported backends
- removed 'uninitialized'/'initialized' states as new approach assumes that init functions take devices implementing ftdi-mpsse traits and return ready-to-use HAL instance

Obvious things that need to be modified during cleanup:
- consistent init API, e.g. default, frequency-only, full featured mpsse settings
- new feature used to select a backend for examples during build time; there should be a better way to do it, but I don't yet figured that out

Thoughts ? Comments ? Concerns ?

Regards,
Sergey