### PR TITLE
Remove the "unproven" feature for input pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           toolchain: stable
       - run: RUSTFLAGS="-D warnings" cargo build
-      - run: RUSTFLAGS="-D warnings" cargo build --features unproven
 
   examples:
     name: Cargo Examples
@@ -42,7 +41,6 @@ jobs:
             sudo apt-get install -y libftdi1 libftdi1-dev pkg-config
           fi
           RUSTFLAGS="-D warnings" cargo build --features ${{ matrix.features }} --examples
-          RUSTFLAGS="-D warnings" cargo build --features ${{ matrix.features }},unproven --examples
 
   test:
     name: Cargo Test
@@ -63,7 +61,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libftdi1 libftdi1-dev pkg-config
           fi
-          RUSTFLAGS="-D warnings" cargo test --features ${{ matrix.features }},unproven
+          RUSTFLAGS="-D warnings" cargo test --features ${{ matrix.features }}
 
   doc:
     name: Cargo Doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added support for input pins with the `"unproven"` feature.
+- Added support for input pins.
 
 ## [0.10.0] - 2021-11-08
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,11 @@ readme = "README.md"
 
 [features]
 libftd2xx-static = ["libftd2xx/static"]
-unproven = ["embedded-hal/unproven"]
 default = []
 
 [dependencies]
 nb = "^1"
-embedded-hal = "~0.2.4"
+embedded-hal = { version = "~0.2.4", features = ["unproven"] }
 ftdi-mpsse = "^0.1"
 libftd2xx = { version = "0.32.0", optional = true }
 ftdi = { version = "0.1.3", optional = true }

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "unproven")]
 use embedded_hal::digital::v2::InputPin;
 use ftdi_embedded_hal as hal;
 use std::{thread::sleep, time::Duration};
@@ -21,16 +20,13 @@ fn main() {
         .open()
         .unwrap();
 
-    let _hal = hal::FtHal::init_default(device).unwrap();
-    #[cfg(feature = "unproven")]
-    let input = _hal.adi6().unwrap();
+    let hal = hal::FtHal::init_default(device).unwrap();
+
+    let input = hal.adi6().unwrap();
 
     println!("Pin readings:");
     loop {
-        #[cfg(feature = "unproven")]
         println!("AD6 = {}", input.is_high().expect("gpio read failure"));
-        #[cfg(not(feature = "unproven"))]
-        println!("Use 'unproven' feature to enable input gpio");
         sleep(SLEEP_DURATION);
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -86,10 +86,9 @@ where
 ///
 /// This is created by calling [`FtHal::adi0`] - [`FtHal::adi7`].
 ///
-/// [`FtHal::ad0`]: crate::FtHal::adi0
-/// [`FtHal::ad7`]: crate::FtHal::adi7
+/// [`FtHal::adi0`]: crate::FtHal::adi0
+/// [`FtHal::adi7`]: crate::FtHal::adi7
 #[derive(Debug)]
-#[cfg(feature = "unproven")]
 pub struct InputPin<'a, Device: MpsseCmdExecutor> {
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
@@ -97,7 +96,6 @@ pub struct InputPin<'a, Device: MpsseCmdExecutor> {
     idx: u8,
 }
 
-#[cfg(feature = "unproven")]
 impl<'a, Device, E> InputPin<'a, Device>
 where
     Device: MpsseCmdExecutor<Error = E>,
@@ -132,7 +130,6 @@ where
     }
 }
 
-#[cfg(feature = "unproven")]
 impl<'a, Device: MpsseCmdExecutor> InputPin<'a, Device> {
     /// Convert the GPIO pin index to a pin mask
     pub(crate) fn mask(&self) -> u8 {
@@ -140,7 +137,6 @@ impl<'a, Device: MpsseCmdExecutor> InputPin<'a, Device> {
     }
 }
 
-#[cfg(feature = "unproven")]
 impl<'a, Device, E> embedded_hal::digital::v2::InputPin for InputPin<'a, Device>
 where
     Device: MpsseCmdExecutor<Error = E>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,6 @@
 
 pub use embedded_hal;
 pub use ftdi_mpsse;
-#[cfg(feature = "unproven")]
-use gpio::InputPin;
 
 mod delay;
 mod error;
@@ -155,7 +153,7 @@ mod spi;
 
 use crate::error::Error;
 pub use delay::Delay;
-pub use gpio::OutputPin;
+pub use gpio::{InputPin, OutputPin};
 pub use i2c::I2c;
 pub use spi::Spi;
 
@@ -164,7 +162,6 @@ use std::{cell::RefCell, sync::Mutex};
 
 /// State tracker for each pin on the FTDI chip.
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(not(feature = "unproven"), allow(dead_code))]
 enum PinUse {
     I2c,
     Spi,
@@ -414,7 +411,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi0(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 0)
     }
@@ -433,7 +429,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi1(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 1)
     }
@@ -452,7 +447,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi2(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 2)
     }
@@ -471,7 +465,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi3(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 3)
     }
@@ -490,7 +483,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi4(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 4)
     }
@@ -509,7 +501,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi5(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 5)
     }
@@ -528,7 +519,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi6(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 6)
     }
@@ -547,7 +537,6 @@ where
     /// # Panics
     ///
     /// Panics if the pin is already in-use.
-    #[cfg(feature = "unproven")]
     pub fn adi7(&self) -> Result<InputPin<Device>, Error<E>> {
         InputPin::new(&self.mtx, 7)
     }


### PR DESCRIPTION
I think it makes sense to enable `"unproven"` by default since there are no more changes expected for `embedded-hal` until the 1.0 release.