### PR TITLE
Added re-exports for libftd2xx and ftdi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added re-exports for `libftd2xx` and `ftdi` when the respective feature is used.
+
 ## [0.11.0] - 2022-01-18
 ### Added
 - Added support for input pins.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FTDI device into the [embedded-hal] traits.
 ```toml
 [dependencies.ftdi-embedded-hal]
 version = "0.11"
-features = ["libftd2xx-static"]
+features = ["libftd2xx", "libftd2xx-static"]
 ```
 
 ## Limitations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```toml
 //! [dependencies.ftdi-embedded-hal]
 //! version = "0.11"
-//! features = ["libftd2xx-static"]
+//! features = ["libftd2xx", "libftd2xx-static"]
 //! ```
 //!
 //! # Limitations
@@ -144,6 +144,12 @@
 
 pub use embedded_hal;
 pub use ftdi_mpsse;
+
+#[cfg(feature = "ftdi")]
+pub use ftdi;
+
+#[cfg(feature = "libftd2xx")]
+pub use libftd2xx;
 
 mod delay;
 mod error;


### PR DESCRIPTION
This makes the crate a little simpler to use because the user only needs to specify in this crate as a dependency in `Cargo.toml` to use it.