### PR TITLE
pass through features for statically linking libftdi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ readme = "README.md"
 
 [features]
 libftd2xx-static = ["libftd2xx/static"]
+ftdi-vendored = ["ftdi/vendored"]
+ftdi-libusb1-sys = ["ftdi/libusb1-sys"]
 default = []
 
 [dependencies]


### PR DESCRIPTION
I added some feature flags that pass through to ftdi-rs because I could not get dynamic linking to work.