### PR TITLE
[fix] enable 0-size transfer

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -653,8 +653,6 @@ where
         for (idx, operation) in operations.iter_mut().enumerate() {
             match operation {
                 Operation::Read(buffer) => {
-                    assert!(!buffer.is_empty(), "buffer must be a non-empty slice");
-
                     if idx == 0 || !prev_op_was_a_read {
                         let mut mpsse_cmd: MpsseCmdBuilder = MpsseCmdBuilder::new();
                         if idx != 0 {
@@ -715,8 +713,6 @@ where
                     prev_op_was_a_read = true;
                 }
                 Operation::Write(bytes) => {
-                    assert!(!bytes.is_empty(), "bytes must be a non-empty slice");
-
                     if idx == 0 || prev_op_was_a_read {
                         let mut mpsse_cmd: MpsseCmdBuilder = MpsseCmdBuilder::new();
                         if idx != 0 {


### PR DESCRIPTION
0-size transfers are valid according to the I2C spec, and used in the [SMB spec](https://www.nxp.com/docs/en/application-note/AN4471.pdf) (§7) as 'quick command'.
It's also useful for scanning I2C busses without impacting devices registers.

It seems to perform correctly with real hardware (start, address, ACK/NAK, stop). 