### PR TITLE
Add with_device method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added a `with_device` method to access device-specific features, such as the EEPROM.
+
 ## [0.23.0] - 2025-03-09
 ### Changed
 - Changed the SPI traits to be implemented on the `SpiDevice` struct, instead of a reference to the struct.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,6 +391,35 @@ where
     E: std::error::Error,
     Error<E>: From<E>,
 {
+    /// Executes the closure with the device.
+    ///
+    /// Useful for accessing EEPROM, or other device-specific functionality.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use ftdi_embedded_hal as hal;
+    /// # #[cfg(feature = "libftd2xx")]
+    /// use hal::libftd2xx::FtdiEeprom;
+    ///
+    /// # #[cfg(feature = "libftd2xx")]
+    /// # {
+    /// let device = libftd2xx::Ft2232h::with_description("Dual RS232-HS A")?;
+    /// let mut hal = hal::FtHal::init_default(device)?;
+    /// let serial_number: String =
+    ///     hal.with_device(|d| d.eeprom_read().map(|(_, strings)| strings.serial_number()))?;
+    /// # }
+    /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn with_device<T, F>(&mut self, mut f: F) -> T
+    where
+        F: FnMut(&mut Device) -> T,
+    {
+        let mut inner = self.mtx.lock().expect("Failed to aquire FTDI mutex");
+        let result: T = f(&mut inner.ft);
+        result
+    }
+
     /// Aquire the SPI peripheral for the FT232H.
     ///
     /// Pin assignments:


### PR DESCRIPTION
This enables access to device-specific features such as the EEPROM.