### PR TITLE
Keep CS pin deasserted after SpiDevice initialization

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -429,6 +429,8 @@ where
             lock.direction &= !(0x07 | cs_mask);
             // set SCK (AD0) and MOSI (AD1), and CS as output pins
             lock.direction |= 0x03 | cs_mask;
+            // deassert CS
+            lock.value |= cs_mask;
 
             // set GPIO pins to new state
             let cmd: MpsseCmdBuilder = MpsseCmdBuilder::new()


### PR DESCRIPTION
SpiDevice keeps CS asserted after initialization. Probably not a problem in many cases, but it makes it hard to find the first SPI transaction on my oscilloscope.